### PR TITLE
Fix dependency declaration in nuspec

### DIFF
--- a/nanoFramework.System.IO.Ports.nuspec
+++ b/nanoFramework.System.IO.Ports.nuspec
@@ -21,7 +21,7 @@ This package requires a target with System.IO.Ports v$nativeVersion$.</descripti
     <tags>nanoFramework C# csharp netmf netnf System.IO.Ports</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.10.3-preview.11" />
-      <dependency id="nanoFramework.Hardware.Esp32" version="1.3.3-preview.14" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Text" version="1.1.1-preview.49" />
     </dependencies>
   </metadata>

--- a/nanoFramework.System.IO.Ports.nuspec
+++ b/nanoFramework.System.IO.Ports.nuspec
@@ -22,7 +22,6 @@ This package requires a target with System.IO.Ports v$nativeVersion$.</descripti
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.10.3-preview.11" />
       <dependency id="nanoFramework.Hardware.Esp32" version="1.3.3-preview.14" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Text" version="1.1.1-preview.49" />
     </dependencies>
   </metadata>

--- a/nanoFramework.System.IO.Ports.nuspec
+++ b/nanoFramework.System.IO.Ports.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>nanoFramework.System.IO.Ports</id>
@@ -22,6 +22,7 @@ This package requires a target with System.IO.Ports v$nativeVersion$.</descripti
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.10.3-preview.11" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
+      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.51" />
       <dependency id="nanoFramework.System.Text" version="1.1.1-preview.49" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
## Description
## Motivation and Context
Remove ESP32 hardware lib from nuspec file as it should not be required for all targets!

## How Has This Been Tested?<!-- (if applicable) -->
TBD

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
