### PR TITLE
General improvements

### DIFF
--- a/System.IO.Ports/Properties/AssemblyInfo.cs
+++ b/System.IO.Ports/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.1.3")]
+[assembly: AssemblyNativeVersion("100.1.2.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -48,7 +48,7 @@ namespace System.IO.Ports
 
         private SerialDataReceivedEventHandler _callbacksDataReceivedEvent = null;
         private SerialStream _stream;
-        private string _newLine = _defaultNewLine;
+        private string _newLine;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerialPort"/> class using the

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -50,7 +50,6 @@ namespace System.IO.Ports
         private SerialStream _stream;
         private string _newLine = _defaultNewLine;
 
-        private Encoding _encoding = Encoding.UTF8;
         /// <summary>
         /// Initializes a new instance of the <see cref="SerialPort"/> class using the
         /// specified port name, baud rate, parity bit, data bits, and stop bit.
@@ -353,22 +352,21 @@ namespace System.IO.Ports
         /// Gets or sets the byte encoding for pre- and post-transmission conversion of text.
         /// </summary>
         /// <exception cref="ArgumentNullException">The <see cref="Encoding"/> property was set to null.</exception>
-        /// <exception cref="ArgumentException">
-        /// The <see cref="Encoding"/> property was set to an encoding that
-        /// is not <see cref="UTF8Encoding"/>.
+        /// <exception cref="NotSupportedException">
+        /// Setting <see cref="Encoding"/> property is not supported in .NET nanoFramework.
         /// </exception>
         /// <remarks>
-        /// .NET nanoFrameowrk implementation of serial port only supports <see cref="UTF8Encoding"/>.
+        /// .NET nanoFramework implementation of serial port only supports <see cref="UTF8Encoding"/>.
         /// </remarks>
 #pragma warning disable S2292 // can't have this adding a automated backing field
         public Encoding Encoding
 #pragma warning restore S2292 // Trivial properties should be auto-implemented
         {
-            get => _encoding;
+            get => Encoding.UTF8;
 
             set
             {
-                _encoding = value;
+                throw new NotSupportedException();
             }
         }
 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -19,10 +19,8 @@ namespace System.IO.Ports
         /// </summary>
         public const int InfiniteTimeout = -1;
 
-        /// <summary>
-        /// Default new Line, you can change and adjust it in the NewLine property
-        /// </summary>
-        public const string DefaultNewLine = "\r\n";
+        // default new line
+        private const string _defaultNewLine = "\r";
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private static readonly SerialDeviceEventListener s_eventListener = new();
@@ -55,7 +53,7 @@ namespace System.IO.Ports
 
         private SerialDataReceivedEventHandler _callbacksDataReceivedEvent = null;
         private SerialStream _stream;
-        private string _newLine = DefaultNewLine;
+        private string _newLine = _defaultNewLine;
 
         private Encoding _encoding = Encoding.UTF8;
         /// <summary>
@@ -89,7 +87,7 @@ namespace System.IO.Ports
                 _parity = parity;
                 _dataBits = dataBits;
                 _stopBits = stopBits;
-                _newLine = DefaultNewLine;
+                _newLine = _defaultNewLine;
 
                 // add serial device to collection
                 SerialDeviceController.DeviceCollection.Add(this);

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -4,8 +4,6 @@
 //
 
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Collections;
 using System.Threading;
 
 namespace System.IO.Ports
@@ -349,26 +347,6 @@ namespace System.IO.Ports
                 throw new NotSupportedException();
             }
         }
-
-        /// <summary>
-        /// Gets or sets the byte encoding for pre- and post-transmission conversion of text.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The <see cref="Encoding"/> property was set to null.</exception>
-        /// <exception cref="NotSupportedException">
-        /// Setting <see cref="Encoding"/> property is not supported in .NET nanoFramework.
-        /// </exception>
-        /// <remarks>
-        /// .NET nanoFramework implementation of serial port only supports <see cref="UTF8Encoding"/>.
-        /// </remarks>
-#pragma warning disable S2292 // can't have this adding a automated backing field
-        public Encoding Encoding
-#pragma warning restore S2292 // Trivial properties should be auto-implemented
-        {
-            get => Encoding.UTF8;
-
-            set
-            {
-                throw new NotSupportedException();
             }
         }
 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -344,9 +344,7 @@ namespace System.IO.Ports
 
             get
             {
-                throw new NotSupportedException();
-            }
-        }
+                return _watchChar;
             }
         }
 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -14,11 +14,6 @@ namespace System.IO.Ports
     /// </summary>
     public sealed class SerialPort : IDisposable
     {
-        /// <summary>
-        /// Indicates that no time-out should occur.
-        /// </summary>
-        public const int InfiniteTimeout = -1;
-
         // default new line
         private const string _defaultNewLine = "\r";
 
@@ -35,8 +30,8 @@ namespace System.IO.Ports
         // flag to signal an open serial port
         private bool _opened;
 
-        private int _writeTimeout = InfiniteTimeout;
-        private int _readTimeout = InfiniteTimeout;
+        private int _writeTimeout = Threading.Timeout.Infinite;
+        private int _readTimeout = Threading.Timeout.Infinite;
         private int _receivedBytesThreshold;
         private int _baudRate;
         private Handshake _handshake = Handshake.None;
@@ -443,7 +438,7 @@ namespace System.IO.Ports
 
             set
             {
-                if ((value < 0) && (value != InfiniteTimeout))
+                if ((value < 0) && (value != Threading.Timeout.Infinite))
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -706,7 +701,7 @@ namespace System.IO.Ports
                     }
                 }
 
-                if ((DateTime.UtcNow >= dtTimeout) && (_readTimeout != InfiniteTimeout))
+                if ((DateTime.UtcNow >= dtTimeout) && (_readTimeout != Threading.Timeout.Infinite))
                 {
                     throw new TimeoutException();
                 }

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -6,6 +6,7 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Collections;
+using System.Threading;
 
 namespace System.IO.Ports
 {
@@ -15,23 +16,24 @@ namespace System.IO.Ports
     public sealed class SerialPort : IDisposable
     {
         // default new line
+        [System.Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private const string _defaultNewLine = "\r";
 
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        [System.Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private static readonly SerialDeviceEventListener s_eventListener = new();
 
         private bool _disposed;
 
         // this is used as the lock object 
         // a lock is required because multiple threads can access the SerialPort
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        [System.Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private readonly object _syncLock = new();
 
         // flag to signal an open serial port
         private bool _opened;
 
-        private int _writeTimeout = Threading.Timeout.Infinite;
-        private int _readTimeout = Threading.Timeout.Infinite;
+        private int _writeTimeout = Timeout.Infinite;
+        private int _readTimeout = Timeout.Infinite;
         private int _receivedBytesThreshold;
         private int _baudRate;
         private Handshake _handshake = Handshake.None;
@@ -405,7 +407,7 @@ namespace System.IO.Ports
         /// <exception cref="IOException">The port is in an invalid state. -or- An attempt to set the state of the underlying
         /// port failed. For example, the parameters passed from this <see cref="SerialPort"/>
         /// object were invalid.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The read time-out value is less than zero and not equal to <see cref="InfiniteTimeout"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The read time-out value is less than zero and not equal to <see cref="Timeout"/>.</exception>
         public int ReadTimeout
         {
             get => _readTimeout;
@@ -429,14 +431,14 @@ namespace System.IO.Ports
         /// port failed. For example, the parameters passed from this <see cref="SerialPort"/>
         /// object were invalid.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The <see cref="WriteTimeout"/> value is less than zero and not equal
-        /// to <see cref="InfiniteTimeout"/>.</exception>
+        /// to <see cref="Timeout"/>.</exception>
         public int WriteTimeout
         {
             get => _writeTimeout;
 
             set
             {
-                if ((value < 0) && (value != Threading.Timeout.Infinite))
+                if ((value < 0) && (value != Timeout.Infinite))
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -467,7 +469,7 @@ namespace System.IO.Ports
         }
 
         /// <summary>
-        /// Gets the underlying System.IO.Stream object for a <see cref="SerialPort"/>
+        /// Gets the underlying <see cref="Stream"/> object for a <see cref="SerialPort"/>
         /// object.
         /// </summary>
         /// <exception cref="InvalidOperationException">The stream is closed. This can occur because the <see cref="Open"/>

--- a/System.IO.Ports/SerialStream.cs
+++ b/System.IO.Ports/SerialStream.cs
@@ -3,9 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.Text;
-
 namespace System.IO.Ports
 {
     internal class SerialStream : Stream
@@ -29,12 +26,14 @@ namespace System.IO.Ports
 
         public override void Flush()
         {
-            _serial.NativeStore();
+            // writing to the stream always sends all the buffer (or times out)
+            // so, there is no real use for this call
+            // adding it just to follow implementation of Stream class
         }
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return (int)_serial.NativeRead(buffer, offset, count);
+            return _serial.Read(buffer, offset, count);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -47,6 +46,7 @@ namespace System.IO.Ports
             throw new NotSupportedException();
         }
 
+        /// <inheritdoc/>
         public override void Write(byte[] buffer, int offset, int count)
         {
             _serial.Write(buffer, offset, count);

--- a/System.IO.Ports/System.IO.Ports.nfproj
+++ b/System.IO.Ports/System.IO.Ports.nfproj
@@ -65,10 +65,6 @@
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Text.1.1.1\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/System.IO.Ports/packages.config
+++ b/System.IO.Ports/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/Tests/UnitTestsSerialPort/SerialTests.cs
+++ b/Tests/UnitTestsSerialPort/SerialTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Ports;
+using System.Text;
 using System.Threading;
 
 namespace UnitTestsSerialPort
@@ -138,7 +139,7 @@ namespace UnitTestsSerialPort
             EnsurePortEmpty(_serTwo);
 
             string toSend = $"I ❤ nanoFramework{_serOne.NewLine}";
-            int enc = _serOne.Encoding.GetBytes(toSend).Length;
+            int enc = Encoding.UTF8.GetBytes(toSend).Length;
             // Act
             _serOne.Write(toSend);
             // Wait a bit to have data sent

--- a/nanoFramework.System.IO.Ports.nuspec
+++ b/nanoFramework.System.IO.Ports.nuspec
@@ -22,7 +22,6 @@ This package requires a target with System.IO.Ports v$nativeVersion$ (checksum $
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.1" />
-      <dependency id="nanoFramework.System.Text" version="1.1.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
- Update DefaultNewLine.  It's now a private const.
- Value changed to \n, to follow .NET implementation see [here](https://docs.microsoft.com/en-us/dotnet/api/system.io.ports.serialport.newline?view=dotnet-plat-ext-5.0#System_IO_Ports_SerialPort_NewLine).
- Replace local InfiniteTimeout with Threading.Timeout.Infinite.
- Remove Encoding property
  + No point on exposing it, as nanoFramework only supports UTF8 encoding.
  + Also allows removing dependency of System.Text.
- Add missing NewLine backing field.
- Add using for System.Threading (smplified access to object within).
- Implement getter for WatchChar.
- Rework native calls:
   + Replace native calls with more obvious one for the "new" IO.Ports API.
   + Update SerialStream accordingly.
- Add pragmas to keep sonarcloud analyser happy.
- Bump AssemblyNativeVersion to 100.1.2.0.

## Motivation and Context
- Align API with full .NET.
- Performance improvement by tossing the code of the various handlers to native code.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
