### PR TITLE
Implement InvertSignalLevels on SerialPort

### DIFF
--- a/System.IO.Ports/Properties/AssemblyInfo.cs
+++ b/System.IO.Ports/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.2.0")]
+[assembly: AssemblyNativeVersion("100.1.3.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -464,6 +464,26 @@ namespace System.IO.Ports
             get;
         }
 
+        /// <summary>
+        /// Gets or sets the logic level of the RX and TX signals. 
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Trying to set this property when the <see cref="SerialPort"/> is already opened and the driver doesn't support it.</exception>
+        /// <exception cref="NotSupportedException">Trying to set this property on a target that does not support signal inversion.</exception>
+        /// <remarks>
+        /// When the signal levels are not inverted (reads <see langword="false"/>) the RX, TX pins use the standard logic levels (VDD = 1/idle, GND = 0/mark).
+        /// Setting this property to <see langword="true"/>, will invert those signal levels, which will become inverted (VDD = 0/mark, GND= 1/idle).
+        /// Some targets may not support this setting and accessing it will throw a <see cref="NotSupportedException"/> exception.
+        /// This is a .NET nanoFramework property only. Doesn't exist on other .NET platforms.
+        /// </remarks>
+        public extern bool InvertSignalLevels
+        {
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            get;
+
+            [MethodImpl(MethodImplOptions.InternalCall)]
+            set;
+        }
+
         #endregion
 
         /// <summary>
@@ -732,7 +752,7 @@ namespace System.IO.Ports
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern string GetDeviceSelector();
-        
+
         #endregion
     }
 }


### PR DESCRIPTION
## Description
- Implement InvertSignalLevels on SerialPort.
- Also bumping AssemblyNativeVersion to 100.1.3.0.

## Motivation and Context
- Allows working with external hardware that works with inverted UART signals or using external transceivers that require inverted signals.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
