### PR TITLE
Add ReadBufferSize and WriteBufferSize

### DIFF
--- a/System.IO.Ports/Properties/AssemblyInfo.cs
+++ b/System.IO.Ports/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.3.0")]
+[assembly: AssemblyNativeVersion("100.1.4.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -49,6 +49,7 @@ namespace System.IO.Ports
         private SerialDataReceivedEventHandler _callbacksDataReceivedEvent = null;
         private SerialStream _stream;
         private string _newLine;
+        private int _bufferSize = 256;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerialPort"/> class using the
@@ -101,6 +102,7 @@ namespace System.IO.Ports
         /// <exception cref="InvalidOperationException">The specified port on the current instance of the <see cref="SerialPort"/>.
         /// is already open.</exception>
         /// <exception cref="ArgumentException">One (or more) of the properties set to configure this <see cref="SerialPort"/> are invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Failed to allocate the request amount of memory for the work buffer.</exception>
         public void Open()
         {
             if (!_opened)
@@ -482,6 +484,86 @@ namespace System.IO.Ports
 
             [MethodImpl(MethodImplOptions.InternalCall)]
             set;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the SerialPort input buffer.
+        /// </summary>
+        /// <value>The size of the input buffer. The default is 256.</value>
+        /// <exception cref="ArgumentOutOfRangeException">The <see cref="ReadBufferSize"/> value is less than or equal to zero.</exception>
+        /// <exception cref="InvalidOperationException">The <see cref="ReadBufferSize"/> property was set while the stream was open.</exception>
+        /// <remarks>
+        /// <para>
+        /// Implementation of this property for .NET nanoFramework it's slightly different from .NET.
+        /// </para>
+        /// <para>
+        /// - There is only one work buffer which is used for transmission and reception.
+        /// </para>
+        /// <para>
+        /// - When the <see cref="SerialPort"/> is <see cref="Open"/> the driver will try to allocate the requested memory for the buffer. On failure to do so, an <see cref="OutOfMemoryException"/> exception will be throw and the <see cref="Open"/> operation will fail.
+        /// </para>
+        /// </remarks>
+        public int ReadBufferSize
+        {
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+
+                if (_opened)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                _bufferSize = value;
+            }
+
+            get
+            {
+                return _bufferSize;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the serial port output buffer.
+        /// </summary>
+        /// <value>The size of the output buffer. The default is 256.</value>
+        /// <exception cref="ArgumentOutOfRangeException">The <see cref="WriteBufferSize"/> value is less than or equal to zero.</exception>
+        /// <exception cref="InvalidOperationException">The <see cref="WriteBufferSize"/> property was set while the stream was open.</exception>
+        /// <remarks>
+        /// <para>
+        /// Implementation of this property for .NET nanoFramework it's slightly different from .NET.
+        /// </para>
+        /// <para>
+        /// - There is only one work buffer which is used for transmission and reception.
+        /// </para>
+        /// <para>
+        /// - When the <see cref="SerialPort"/> is <see cref="Open"/> the driver will try to allocate the requested memory for the buffer. On failure to do so, an <see cref="OutOfMemoryException"/> exception will be throw and the <see cref="Open"/> operation will fail.
+        /// </para>
+        /// </remarks>
+        public int WriteBufferSize
+        {
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+
+                if (_opened)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                _bufferSize = value;
+            }
+
+            get
+            {
+                return _bufferSize;
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Description
- Add ReadBufferSize and WriteBufferSize to SerialPort.

## Motivation and Context
- This empowers developers to configure the size of the serial work buffer which has been hard-coded in native. The default size it's the same as it was when hard-coded, so there are no breaking changes, no impact on feature and no compromise on the memory allocation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
