### PR TITLE
Align default newline with .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ port.WriteLine(toSend);
 // this will send the string encoded finishing by a new line, by default `\n`
 // You can change the new line to be anything:
 port.NewLine = "❤❤";
-// Now it will send use 2 hearts as the line ending for `ReadLine` or `WriteLine`
+// Now it will send 2 hearts as the line ending `WriteLine` and will use 2 hearts as the terminator for `ReadLine`.
 // You can change it back to the `\n` default at anytime:
 port.NewLine = SerialPort.DefaultNewLine; // default is "\n"
 // This will read the existing buffer:

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ You can as well write and read strings:
 ```csharp
 string toSend = "I ❤ nanoFramework";
 port.WriteLine(toSend);
-// this will send the string encoded finishing by a new line, by default \r\n
-// You can change the new line by anything:
+// this will send the string encoded finishing by a new line, by default `\n`
+// You can change the new line to be anything:
 port.NewLine = "❤❤";
-// Now it will send the 2 hearts as the end of line while operating a ReadLine or WriteLine
-// You can ad anytime change it back:
-port.NewLine = SerialPort.DefaultNewLine; // default is "\r\n"
+// Now it will send use 2 hearts as the line ending for `ReadLine` or `WriteLine`
+// You can change it back to the `\n` default at anytime:
+port.NewLine = SerialPort.DefaultNewLine; // default is "\n"
 // This will read the existing buffer:
 string existingString = port.ReadExisting();
 // Note that if it can't properly convert the bytes to a string, you'll get an exception

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -15,7 +15,7 @@ namespace System.IO.Ports
     {
         // default new line
         [System.Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
-        private const string _defaultNewLine = "\r";
+        private const string _defaultNewLine = "\n";
 
         [System.Diagnostics.DebuggerBrowsable(Diagnostics.DebuggerBrowsableState.Never)]
         private static readonly SerialDeviceEventListener s_eventListener = new();

--- a/Tests/UnitTestsSerialPort/README.md
+++ b/Tests/UnitTestsSerialPort/README.md
@@ -1,0 +1,5 @@
+# SerialPort Unit Tests
+Note:
+The current unit tests only run on real hardware, and are currently setup for ESP32 devices with `COM2` and `COM3` available and interconnected.
+Other devices can be added easily by changing the `SetupComPorts` in [SerialTests.cs](SerialTests.cs).
+

--- a/Tests/UnitTestsSerialPort/SerialTests.cs
+++ b/Tests/UnitTestsSerialPort/SerialTests.cs
@@ -94,6 +94,23 @@ namespace UnitTestsSerialPort
         }
 
         [TestMethod]
+        public void VerifyDefaultReadLineCharacter()
+        {
+            // Arrange
+            EnsurePortsOpen();
+            _serOne.WriteTimeout = 1000;
+            _serOne.ReadTimeout = 1000;
+            _serTwo.WriteTimeout = 1000;
+            _serTwo.ReadTimeout = 1000;
+            string toSend = "This is a simple test for verifying the default readline character\\r\\n";
+            // Act
+            _serOne.Write(toSend);
+            string toReceive = _serTwo.ReadLine();
+            // Assert
+            Assert.Equal(toSend, toReceive + "\\r" + _serOne.NewLine);
+        }
+
+        [TestMethod]
         public void WriteAndReadStringTests()
         {
             // Arrange

--- a/Tests/UnitTestsSerialPort/SerialTests.cs
+++ b/Tests/UnitTestsSerialPort/SerialTests.cs
@@ -102,7 +102,7 @@ namespace UnitTestsSerialPort
             _serOne.ReadTimeout = 1000;
             _serTwo.WriteTimeout = 1000;
             _serTwo.ReadTimeout = 1000;
-            string toSend = "This is a simple test for verifying the default readline character\\r\\n";
+            string toSend = "This is a simple test for verifying the default readline character \r\n \\r";
             // Act
             _serOne.Write(toSend);
             string toReceive = _serTwo.ReadLine();

--- a/Tests/UnitTestsSerialPort/nano.runsettings
+++ b/Tests/UnitTestsSerialPort/nano.runsettings
@@ -9,6 +9,6 @@
    </RunConfiguration>
    <nanoFrameworkAdapter>
        <Logging>None</Logging>
-       <IsRealHardware>True</IsRealHardware>
+       <IsRealHardware>False</IsRealHardware>
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/Tests/UnitTestsSerialPort/nano.runsettings
+++ b/Tests/UnitTestsSerialPort/nano.runsettings
@@ -9,6 +9,6 @@
    </RunConfiguration>
    <nanoFrameworkAdapter>
        <Logging>None</Logging>
-       <IsRealHardware>False</IsRealHardware>
+       <IsRealHardware>True</IsRealHardware>
    </nanoFrameworkAdapter>
 </RunSettings>


### PR DESCRIPTION
## Description
* The default newline char was `\r` whereas the .NET implementation uses `\n`
see https://github.com/dotnet/runtime/blob/478b1b43c89f0f1fa3b2c94d7b444f7a8325d401/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.cs#L35

## Motivation and Context
* Most serial devices use windows line endings (just incase) as default and the nF implementation causes extra steps.

## How Has This Been Tested?
Requires verifying on a local target.

## Screenshots

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
