### PR TITLE
Fix implementation of timeout properties

### DIFF
--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -383,14 +383,14 @@ namespace System.IO.Ports
         /// <exception cref="IOException">The port is in an invalid state. -or- An attempt to set the state of the underlying
         /// port failed. For example, the parameters passed from this <see cref="SerialPort"/>
         /// object were invalid.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The read time-out value is less than zero and not equal to <see cref="Timeout"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The read time-out value is less than zero and not equal to <see cref="Timeout.Infinite"/>.</exception>
         public int ReadTimeout
         {
             get => _readTimeout;
 
             set
             {
-                if (value <= 0)
+                if (value is < 0 && value != Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -406,15 +406,14 @@ namespace System.IO.Ports
         /// <exception cref="IOException">The port is in an invalid state. -or- An attempt to set the state of the underlying
         /// port failed. For example, the parameters passed from this <see cref="SerialPort"/>
         /// object were invalid.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The <see cref="WriteTimeout"/> value is less than zero and not equal
-        /// to <see cref="Timeout"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The read time-out value is less than zero and not equal to <see cref="Timeout.Infinite"/>.</exception>
         public int WriteTimeout
         {
             get => _writeTimeout;
 
             set
             {
-                if ((value < 0) && (value != Timeout.Infinite))
+                if (value is < 0 && value != Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -390,7 +390,7 @@ namespace System.IO.Ports
 
             set
             {
-                if (value is < 0 and value is not Timeout.Infinite)
+                if (value < 0 && value != Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -413,7 +413,7 @@ namespace System.IO.Ports
 
             set
             {
-                if (value is < 0 and value is not Timeout.Infinite)
+                if (value < 0 && value != Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }

--- a/System.IO.Ports/SerialPort.cs
+++ b/System.IO.Ports/SerialPort.cs
@@ -390,7 +390,7 @@ namespace System.IO.Ports
 
             set
             {
-                if (value is < 0 && value != Timeout.Infinite)
+                if (value is < 0 and value is not Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }
@@ -413,7 +413,7 @@ namespace System.IO.Ports
 
             set
             {
-                if (value is < 0 && value != Timeout.Infinite)
+                if (value is < 0 and value is not Timeout.Infinite)
                 {
                     throw new ArgumentOutOfRangeException();
                 }


### PR DESCRIPTION
## Description
- Validation was wrong.
- Exception comment was wrongly formatted.

## Motivation and Context
- Obvious fixes required.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
